### PR TITLE
Debug for requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,7 +7,7 @@ palettable>=3.0.0
 pandas==0.18.1
 patsy>=0.4.0
 pymc>=2.3.6
-rpy2>=2.3.10
+rpy2==2.3.10
 scikit-learn==0.18.1
 seaborn==0.7.0
 statsmodels==0.6.1


### PR DESCRIPTION
Greetings:

It seems SECIMTools is created based on Python-2, while the error report said the latest rpy2 does not support Python-2 when I was trying to "pip install" it, so I replaced ">=" with "==" and then the error message was removed.